### PR TITLE
makes use of the high byte in ReadLoad, returns a signed integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ servo.ListServos()
 Get the motor load (duty cycle) as signed integer between 1023 to -1024 . Return `None` in case of error.
 
 - **Parameters**: `sts_id` (int)
-- **Returns**: `float` or `None`
+- **Returns**: `int` or `None`
 - **Example**:
 ```python
 servo.ReadLoad(1)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ servo.ListServos()
 ---
 
 ### `ReadLoad(sts_id)`
-Get the motor load in %. Return `None` in case of error.
+Get the motor load (duty cycle) as signed integer between 1023 to -1024 . Return `None` in case of error.
 
 - **Parameters**: `sts_id` (int)
 - **Returns**: `float` or `None`

--- a/st3215/st3215.py
+++ b/st3215/st3215.py
@@ -57,18 +57,20 @@ class ST3215(protocol_packet_handler):
 
     def ReadLoad(self, sts_id):
         """
-        Load of the servo. 
-        Load value is determined by: The voltage duty cycle of the current control output driving motor
+        Load of the servo.
+        Load value is the 10 bit duty cycle of the motor controller
 
         :param sts_id: Servo ID
 
-        :return: Load value in percentage. None in case of error.
+        :return: motor duty cycle +1023 to -1024. None in case of error.
         """
-        load, comm, error = self.read1ByteTxRx(sts_id, STS_PRESENT_LOAD_L)
+        load, comm, error = self.read2ByteTxRx(sts_id, STS_PRESENT_LOAD_L)
         if comm == 0 and error == 0:
-            return load * 0.1
+          if load >= 1<<10:
+            load = (1<<10) - load
+          return load
         else:
-            return None
+          return None
 
     def ReadVoltage(self, sts_id):
         """

--- a/st3215/st3215.py
+++ b/st3215/st3215.py
@@ -66,11 +66,11 @@ class ST3215(protocol_packet_handler):
         """
         load, comm, error = self.read2ByteTxRx(sts_id, STS_PRESENT_LOAD_L)
         if comm == 0 and error == 0:
-          if load >= 1<<10:
-            load = (1<<10) - load
-          return load
+            if load >= 1<<10:
+                load = (1<<10) - load
+            return load
         else:
-          return None
+            return None
 
     def ReadVoltage(self, sts_id):
         """


### PR DESCRIPTION

Handles https://github.com/Mickael-Roger/python-st3215/issues/16

I've also changed ReadLoad return to an int, having a range include "minus 100%" felt a bit too arbitrary compared to the native range
This works on my FeeTech ST3215 12V motors, and allows a trivial loop to define a friction model

Cheers